### PR TITLE
Add build and test github workflow

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,0 +1,53 @@
+name: Java CI with gradle
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and Test
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java: [17]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # checkout to specmatic-google-pubsub-sample project
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'oracle'
+          java-version: ${{ matrix.java }}
+
+      # publish specmatic-google-pubsub jar to local maven repo
+      - name: Checkout specmatic-google-pubsub repo
+        uses: actions/checkout@v4
+        with:
+          repository: znsio/specmatic-google-pubsub
+          path: specmatic-google-pubsub
+          token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}
+
+      - name: Grant execute permission for gradlew
+        working-directory: specmatic-google-pubsub
+        run: chmod +x gradlew
+
+      - name: Publish specmatic-google-pubsub to Local Maven Repo
+        working-directory: specmatic-google-pubsub
+        run: ./gradlew publishToMavenLocal
+      
+      # Build and test specmatic-google-pubsub-sample project 
+      - name: Grant execute permission for gradlew on specmatic-google-pubsub-sample repo
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build


### PR DESCRIPTION
- [x] Publishes the specmatic-google-pubsub jar to local maven repo.
- [x] Checks out to specmatic-google-pubsub-sample project and builds it using the testcontainers.

Open point - Not sure about how ACTIONS_GITHUB_TOKEN env variable will be accessed by the workflow.